### PR TITLE
sslopt dict ca_cert should be ca_certs, fixes #334

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -170,7 +170,7 @@ def _ssl_socket(sock, user_sslopt, hostname):
     else:
         certPath = os.path.join(
             os.path.dirname(__file__), "cacert.pem")
-    if os.path.isfile(certPath) and user_sslopt.get('ca_cert', None) is None:
+    if os.path.isfile(certPath) and user_sslopt.get('ca_certs', None) is None:
         sslopt['ca_certs'] = certPath
     elif os.path.isdir(certPath) and user_sslopt.get('ca_cert_path', None) is None:
         sslopt['ca_cert_path'] = certPath


### PR DESCRIPTION
Was 2/3 fixed in commits  287db85 and c280375.